### PR TITLE
[#72] 대소문자 구분하지 않는 버그

### DIFF
--- a/BE/src/main/java/com/codesquad/team1/signup/repository/UserRepository.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/repository/UserRepository.java
@@ -5,12 +5,12 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface UserRepository extends CrudRepository<User, Integer> {
 
-    @Query("select count(*) from USERS where user_id = :userId")
+    @Query("select count(*) from USERS where binary user_id = :userId")
     long findByUserId(String userId);
 
-    @Query("select count(*) from USERS where email = :email")
+    @Query("select count(*) from USERS where binary email = :email")
     long findByEmail(String email);
 
-    @Query("select count(*) from USERS where phone_number = :phoneNumber")
+    @Query("select count(*) from USERS where binary phone_number = :phoneNumber")
     long findByPhoneNumber(String phoneNumber);
 }


### PR DESCRIPTION
fix #72 

- 요청된 내용이 잘못된 경우, 에러를 어떻게 처리할지 프론트분들과 상의해야할 것 같아요. 현재는 잘못 요청된 URL에 대해서 500 오류가 발생하도록 되어있습니다.
- 이슈 두 개 달아서 죄송합니다...ㅋㅋㅋ
---
- 원복하고 대소문자 구분 버그만 해결한 것으로 push --force 하겠습니다.