### PR TITLE
[#8] 개인 정보 조회 API 구현

### DIFF
--- a/BE/src/main/java/com/codesquad/team1/signup/Exception/ForbiddenException.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/Exception/ForbiddenException.java
@@ -3,5 +3,10 @@ package com.codesquad.team1.signup.Exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "접근 권한이 없습니다.")
-public class ForbiddenException extends RuntimeException {}
+@ResponseStatus(value = HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/BE/src/main/java/com/codesquad/team1/signup/Exception/ForbiddenException.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/Exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.codesquad.team1.signup.Exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "접근 권한이 없습니다.")
+public class ForbiddenException extends RuntimeException {}

--- a/BE/src/main/java/com/codesquad/team1/signup/Exception/UnauthorizedException.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/Exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.codesquad.team1.signup.Exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.UNAUTHORIZED, reason = "로그인이 필요합니다.")
+public class UnauthorizedException extends RuntimeException{}

--- a/BE/src/main/java/com/codesquad/team1/signup/Exception/UnauthorizedException.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/Exception/UnauthorizedException.java
@@ -3,5 +3,10 @@ package com.codesquad.team1.signup.Exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value = HttpStatus.UNAUTHORIZED, reason = "로그인이 필요합니다.")
-public class UnauthorizedException extends RuntimeException{}
+@ResponseStatus(value = HttpStatus.UNAUTHORIZED)
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/BE/src/main/java/com/codesquad/team1/signup/controller/ApiUserController.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/controller/ApiUserController.java
@@ -51,10 +51,9 @@ public class ApiUserController {
     @PostMapping("/login")
     public boolean login(@RequestBody User loginUser, HttpSession session) {
         User user = userRepository.findByUserId(loginUser.getUserId()).orElseGet(User::new);
-
-        if (!user.matchPassword(loginUser))
+        if (!user.matchPassword(loginUser)) {
             return false;
-
+        }
         session.setAttribute(SESSION_USER_KEY, user);
         return true;
     }
@@ -68,12 +67,11 @@ public class ApiUserController {
 
     @GetMapping("/{id}")
     public User showPersonalInformation(@PathVariable String id, HttpSession session) {
-        User sessionedUser = (User)Optional.ofNullable(session.getAttribute(SESSION_USER_KEY)).orElseThrow(UnauthorizedException::new);
+        User sessionedUser = Optional.ofNullable((User)session.getAttribute(SESSION_USER_KEY)).orElseThrow(() -> new UnauthorizedException("접근 권한이 없습니다."));
         User requestedUser = userRepository.findById(id).orElseGet(User::new);
-
-        if (!sessionedUser.matchUser(requestedUser))
-            throw new ForbiddenException();
-
+        if (!sessionedUser.equals(requestedUser)) {
+            throw new ForbiddenException("로그인이 필요합니다.");
+        }
         return requestedUser;
     }
 }

--- a/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
@@ -104,7 +104,8 @@ public class User {
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
         return userId.equals(user.userId) &&
-                password.equals(user.password);
+                email.equals(user.email) &&
+                phoneNumber.equals(user.phoneNumber);
     }
 
     @Override

--- a/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.regex.Matcher;
 
 import static com.codesquad.team1.signup.constants.ValidationConstants.USER_EMAIL_VALIDATION_PATTERN;
@@ -97,7 +98,17 @@ public class User {
         return this.password != null && this.password.equals(loginUser.password);
     }
 
-    public boolean matchUser(User requestedUser) {
-        return this.id == requestedUser.id;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return userId.equals(user.userId) &&
+                password.equals(user.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, password);
     }
 }

--- a/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
@@ -96,4 +96,8 @@ public class User {
     public boolean matchPassword(User loginUser) {
         return this.password != null && this.password.equals(loginUser.password);
     }
+
+    public boolean matchUser(User requestedUser) {
+        return this.id == requestedUser.id;
+    }
 }

--- a/BE/src/main/java/com/codesquad/team1/signup/repository/UserRepository.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/repository/UserRepository.java
@@ -18,4 +18,7 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 
     @Query("select * from USERS where binary user_id = :userId")
     Optional<User> findByUserId(String userId);
+
+    @Query("select * from USERS where id = :id")
+    Optional<User> findById(String id);
 }


### PR DESCRIPTION
Closed #8

- 로그아웃된 사용자가 해당 api url을 요청하면 Unauthorized 상태 코드를 지정한 예외 클래스를 throw합니다.
- 로그인 사용자와 다른 회원의 개인 정보를 요청하면 Forbidden 상태 코드를 지정한 예외 클래스를 throw합니다.

계획
- issue 생성해서 예외 상황 응답 객체를 만들려고 합니다. (예외 상황이 발생한 경우에는 통일된 객체를 리턴하도록)

궁금한 점
- 개인정보를 반환할 때 password가 함께 보내지는 것은 안좋은 것 같아서 password 필드를 갖지 않은 DTO 클래스를 생성할까 했는데 이렇게 만들면 로그인 요청 시 전달되는 데이터를 받기 위해서 DTO를 사용할 수 없을 것 같아서 고민입니다.