### PR TITLE
[#107] Refactor: 에러 발생 시 응답 객체 구현

### DIFF
--- a/BE/src/main/java/com/codesquad/team1/signup/Exception/ErrorResponse.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/Exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.codesquad.team1.signup.Exception;
+
+public class ErrorResponse {
+
+    private String message;
+    private int status;
+
+    public ErrorResponse(String message, int status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/BE/src/main/java/com/codesquad/team1/signup/Exception/ForbiddenException.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/Exception/ForbiddenException.java
@@ -1,9 +1,5 @@
 package com.codesquad.team1.signup.Exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(value = HttpStatus.FORBIDDEN)
 public class ForbiddenException extends RuntimeException {
 
     public ForbiddenException(String message) {

--- a/BE/src/main/java/com/codesquad/team1/signup/Exception/UnauthorizedException.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/Exception/UnauthorizedException.java
@@ -1,9 +1,5 @@
 package com.codesquad.team1.signup.Exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(value = HttpStatus.UNAUTHORIZED)
 public class UnauthorizedException extends RuntimeException {
 
     public UnauthorizedException(String message) {

--- a/BE/src/main/java/com/codesquad/team1/signup/controller/ApiUserController.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/controller/ApiUserController.java
@@ -9,7 +9,6 @@ import com.codesquad.team1.signup.response.ValidationResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 

--- a/BE/src/main/java/com/codesquad/team1/signup/controller/ApiUserController.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/controller/ApiUserController.java
@@ -91,12 +91,12 @@ public class ApiUserController {
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
-        return new ResponseEntity<>(new ErrorResponse(e.getMessage(), HttpStatus.UNAUTHORIZED.value()), HttpStatus.UNAUTHORIZED);
+    public ErrorResponse handleUnauthorizedException(UnauthorizedException e) {
+        return new ErrorResponse(e.getMessage(), HttpStatus.UNAUTHORIZED.value());
     }
 
     @ExceptionHandler(ForbiddenException.class)
-    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
-        return new ResponseEntity<>(new ErrorResponse(e.getMessage(), HttpStatus.FORBIDDEN.value()), HttpStatus.FORBIDDEN);
+    public ErrorResponse handleForbiddenException(ForbiddenException e) {
+        return new ErrorResponse(e.getMessage(), HttpStatus.FORBIDDEN.value());
     }
 }


### PR DESCRIPTION
Closed #107

- ErrorResponse 객체에 에러 메세지와 http 상태 코드를 저장.
- 현재 하나의 컨트롤러 밖에 존재하지 않기 때문에 해당 컨트롤러 안에서@ExceptionHandler를 이용해서 예외 상황을 처리하도록 구현함.