### PR TITLE
[#110] Fix: 관심사가 여러개 저장되지 않는 문제 해결

### DIFF
--- a/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
+++ b/BE/src/main/java/com/codesquad/team1/signup/repository/User.java
@@ -28,7 +28,7 @@ public class User {
     private String email;
     private String phoneNumber;
 
-    @MappedCollection(idColumn = "uid", keyColumn = "id")
+    @MappedCollection(idColumn = "uid", keyColumn = "interest_key")
     private List<Interest> interests;
 
     public int getId() {


### PR DESCRIPTION
 - @MappedCollection 의 이해 부족으로 인해 초래된 문제입니다.
 - key Column으로 저장될 값을 저장할 field를 DB에 추가하였습니다.
 - @MappedCollection의 Key Column 값은 0, 1 순서로 추가됩니다.
 - Fixed #110 Issue.